### PR TITLE
add openPMD reference to yt interface

### DIFF
--- a/yt/frontends/api.py
+++ b/yt/frontends/api.py
@@ -32,6 +32,7 @@ _frontends = [
     'halo_catalog',
     'http_stream',
     'moab',
+    'openPMD',
     'owls',
     'owls_subfind',
     'ramses',

--- a/yt/frontends/setup.py
+++ b/yt/frontends/setup.py
@@ -22,6 +22,7 @@ def configuration(parent_package='', top_path=None):
     config.add_subpackage("halo_catalog")
     config.add_subpackage("http_stream")
     config.add_subpackage("moab")
+    config.add_subpackage("openPMD")
     config.add_subpackage("owls")
     config.add_subpackage("owls_subfind")
     config.add_subpackage("ramses")


### PR DESCRIPTION
added the string 'openPMD' to setup.py and api.py, so yt finds the 'openPMD' directory in the 'frontends' directory.
